### PR TITLE
Implement CTM swarm coordinator core

### DIFF
--- a/.changeset/coordinator-core.md
+++ b/.changeset/coordinator-core.md
@@ -1,0 +1,5 @@
+---
+"task-master-ai": minor
+---
+
+Add Coordinator core for CTM swarm.

--- a/ctm_swarm/coordinator.py
+++ b/ctm_swarm/coordinator.py
@@ -136,7 +136,7 @@ class Coordinator:
                 os.unlink(tmp)
             raise RuntimeError(f"Failed to flush tasks to {self.tasks_path}: {e}")
 
-    def _emit_event(self, event: str, task_id: str, agent_id: str, success: bool | None = None) -> None:
+    def _emit_event(self, event: str, task_id: str, agent_id: str, success: Optional[bool] = None) -> None:
         payload = {"event": event, "task_id": task_id, "agent_id": agent_id}
         if success is not None:
             payload["success"] = success

--- a/ctm_swarm/coordinator.py
+++ b/ctm_swarm/coordinator.py
@@ -37,8 +37,11 @@ class Coordinator:
 
     def load_tasks(self, path: str) -> None:
         self.tasks_path = path
-        with open(path, "r") as f:
-            data = json.load(f)
+        try:
+            with open(path, "r") as f:
+                data = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            raise ValueError(f"Failed to load tasks from {path}: {e}")
         self.tasks = {}
         self.dependents = {}
         for raw in data.get("tasks", []):

--- a/ctm_swarm/coordinator.py
+++ b/ctm_swarm/coordinator.py
@@ -106,7 +106,7 @@ class Coordinator:
         for p in task.impactSet:
             self.locked_paths.discard(p)
         for dep_id in self.dependents.get(task_id, []):
-            self.blocked_count[dep_id] = max(0, self.blocked_count.get(dep_id, 1) - 1)
+            self.blocked_count[dep_id] = max(0, self.blocked_count.get(dep_id, 0) - 1)
             dep_task = self.tasks[dep_id]
             if dep_task.status == "pending" and self.blocked_count[dep_id] == 0:
                 priority = PRIORITY_ORDER.get(dep_task.priority, 1)

--- a/ctm_swarm/coordinator.py
+++ b/ctm_swarm/coordinator.py
@@ -126,9 +126,15 @@ class Coordinator:
         data = {
             "tasks": [dataclasses.asdict(t) for t in self.tasks.values()]
         }
-        with open(tmp, "w") as f:
-            json.dump(data, f, indent=2)
-        os.replace(tmp, self.tasks_path)
+        try:
+            with open(tmp, "w") as f:
+                json.dump(data, f, indent=2)
+            os.replace(tmp, self.tasks_path)
+        except (IOError, OSError) as e:
+            # Clean up temp file on failure
+            if os.path.exists(tmp):
+                os.unlink(tmp)
+            raise RuntimeError(f"Failed to flush tasks to {self.tasks_path}: {e}")
 
     def _emit_event(self, event: str, task_id: str, agent_id: str, success: bool | None = None) -> None:
         payload = {"event": event, "task_id": task_id, "agent_id": agent_id}

--- a/ctm_swarm/coordinator.py
+++ b/ctm_swarm/coordinator.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import heapq
+import json
+import os
+from dataclasses import dataclass
+import dataclasses
+from typing import Dict, List, Optional
+
+
+PRIORITY_ORDER = {
+    "high": 0,
+    "medium": 1,
+    "low": 2,
+}
+
+
+@dataclass
+class Task:
+    id: str
+    dependencies: List[str]
+    priority: str
+    createdAt: str
+    impactSet: List[str]
+    status: str = "pending"
+    agent: Optional[str] = None
+
+
+class Coordinator:
+    def __init__(self) -> None:
+        self.tasks: Dict[str, Task] = {}
+        self.dependents: Dict[str, List[str]] = {}
+        self.blocked_count: Dict[str, int] = {}
+        self.ready_heap: List[tuple] = []
+        self.locked_paths: set[str] = set()
+        self.tasks_path: str = ""
+
+    def load_tasks(self, path: str) -> None:
+        self.tasks_path = path
+        with open(path, "r") as f:
+            data = json.load(f)
+        self.tasks = {}
+        self.dependents = {}
+        for raw in data.get("tasks", []):
+            task = Task(
+                id=str(raw["id"]),
+                dependencies=[str(d) for d in raw.get("dependencies", [])],
+                priority=raw.get("priority", "medium"),
+                createdAt=raw.get("createdAt", ""),
+                impactSet=raw.get("impactSet", []),
+                status=raw.get("status", "pending"),
+            )
+            self.tasks[task.id] = task
+            for dep in task.dependencies:
+                self.dependents.setdefault(dep, []).append(task.id)
+
+        self._recalculate_blocked()
+        self._build_ready_heap()
+
+    def _recalculate_blocked(self) -> None:
+        self.blocked_count = {}
+        for task in self.tasks.values():
+            count = 0
+            for dep in task.dependencies:
+                dep_task = self.tasks.get(dep)
+                if dep_task and dep_task.status != "done":
+                    count += 1
+            self.blocked_count[task.id] = count
+
+    def _build_ready_heap(self) -> None:
+        self.ready_heap = []
+        for task in self.tasks.values():
+            if task.status == "pending" and self.blocked_count.get(task.id, 0) == 0:
+                priority = PRIORITY_ORDER.get(task.priority, 1)
+                heapq.heappush(
+                    self.ready_heap, (priority, task.createdAt, task.id)
+                )
+        heapq.heapify(self.ready_heap)
+
+    def pick_tasks(self, n: int) -> List[Task]:
+        picked: List[Task] = []
+        skipped: List[tuple] = []
+        while self.ready_heap and len(picked) < n:
+            item = heapq.heappop(self.ready_heap)
+            task = self.tasks[item[2]]
+            if any(p in self.locked_paths for p in task.impactSet):
+                skipped.append(item)
+                continue
+            self.locked_paths.update(task.impactSet)
+            picked.append(task)
+        for item in skipped:
+            heapq.heappush(self.ready_heap, item)
+        return picked
+
+    def mark_in_progress(self, task_id: str, agent_id: str) -> None:
+        task = self.tasks[task_id]
+        task.status = "in-progress"
+        task.agent = agent_id
+        self._flush()
+        self._emit_event("TASK_STARTED", task_id, agent_id)
+
+    def mark_done(self, task_id: str, agent_id: str, success: bool = True) -> None:
+        task = self.tasks[task_id]
+        task.status = "done"
+        task.agent = agent_id
+        for p in task.impactSet:
+            self.locked_paths.discard(p)
+        for dep_id in self.dependents.get(task_id, []):
+            self.blocked_count[dep_id] = max(0, self.blocked_count.get(dep_id, 1) - 1)
+            dep_task = self.tasks[dep_id]
+            if dep_task.status == "pending" and self.blocked_count[dep_id] == 0:
+                priority = PRIORITY_ORDER.get(dep_task.priority, 1)
+                heapq.heappush(
+                    self.ready_heap, (priority, dep_task.createdAt, dep_task.id)
+                )
+        self._flush()
+        self._emit_event("TASK_DONE", task_id, agent_id, success)
+
+    def _flush(self) -> None:
+        if not self.tasks_path:
+            return
+        tmp = self.tasks_path + ".tmp"
+        data = {
+            "tasks": [dataclasses.asdict(t) for t in self.tasks.values()]
+        }
+        with open(tmp, "w") as f:
+            json.dump(data, f, indent=2)
+        os.replace(tmp, self.tasks_path)
+
+    def _emit_event(self, event: str, task_id: str, agent_id: str, success: bool | None = None) -> None:
+        payload = {"event": event, "task_id": task_id, "agent_id": agent_id}
+        if success is not None:
+            payload["success"] = success
+        print(json.dumps(payload), flush=True)

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ Welcome to the Task Master documentation. Use the links below to navigate to the
 
 - [Command Reference](command-reference.md) - Complete list of all available commands
 - [Task Structure](task-structure.md) - Understanding the task format and features
+- [CTM Swarm Coordinator](ctm-swarm.md) - Multi-agent task orchestration
 
 ## Examples & Licensing
 

--- a/docs/ctm-swarm.md
+++ b/docs/ctm-swarm.md
@@ -1,0 +1,30 @@
+# CTM Swarm Coordinator
+
+The CTM Swarm is a set of utilities that allow multiple agents to work on a single
+Task Master project. The `Coordinator` is responsible for orchestrating which tasks
+are ready to be worked on and ensuring that agents do not step on each other's work.
+
+## Coordinator Responsibilities
+
+- **Dependency Tracking** – tasks are only made available when all of their
+  dependencies are marked `done`.
+- **Priority Queue** – ready tasks are ordered by priority and creation time.
+- **Conflict Lock** – while a task is active its `impactSet` paths are locked so
+  no other task can modify the same files.
+- **State Flush** – task state is written back to `tasks.json` atomically.
+- **Event Hook** – JSON events are printed when tasks start and finish.
+
+## Usage Example
+
+```python
+from ctm_swarm.coordinator import Coordinator
+
+c = Coordinator()
+c.load_tasks("/path/to/tasks.json")
+ready = c.pick_tasks(1)
+if ready:
+    task = ready[0]
+    c.mark_in_progress(task.id, "agent-1")
+    # ...work on the task...
+    c.mark_done(task.id, "agent-1")
+```

--- a/tests/swarm/test_coordinator.py
+++ b/tests/swarm/test_coordinator.py
@@ -1,0 +1,63 @@
+import json
+import os
+import tempfile
+import unittest
+
+from ctm_swarm.coordinator import Coordinator
+
+
+SAMPLE_TASKS = {
+    "tasks": [
+        {
+            "id": "1",
+            "dependencies": [],
+            "priority": "high",
+            "createdAt": "2024-01-01T00:00:00Z",
+            "impactSet": ["A"],
+            "status": "pending",
+        },
+        {
+            "id": "2",
+            "dependencies": ["1"],
+            "priority": "medium",
+            "createdAt": "2024-01-02T00:00:00Z",
+            "impactSet": ["B"],
+            "status": "pending",
+        },
+    ]
+}
+
+
+class CoordinatorTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        self.tasks_path = os.path.join(self.tmpdir.name, "tasks.json")
+        with open(self.tasks_path, "w") as f:
+            json.dump(SAMPLE_TASKS, f)
+        self.coordinator = Coordinator()
+        self.coordinator.load_tasks(self.tasks_path)
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def test_pick_highest_priority(self):
+        tasks = self.coordinator.pick_tasks(1)
+        self.assertEqual(len(tasks), 1)
+        self.assertEqual(tasks[0].id, "1")
+
+    def test_pick_reserves_paths(self):
+        self.coordinator.pick_tasks(1)
+        self.assertIn("A", self.coordinator.locked_paths)
+
+    def test_mark_done_unlocks_dependents(self):
+        tasks = self.coordinator.pick_tasks(1)
+        self.coordinator.mark_in_progress(tasks[0].id, "agent")
+        self.coordinator.mark_done(tasks[0].id, "agent")
+        self.assertNotIn("A", self.coordinator.locked_paths)
+        ready = self.coordinator.pick_tasks(1)
+        self.assertEqual(len(ready), 1)
+        self.assertEqual(ready[0].id, "2")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `Coordinator` class for CTM swarm
- document multi-agent coordinator usage
- reference new doc from documentation index
- add tests for Coordinator

## Testing
- `npm test`
- `python -m unittest tests/swarm/test_coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_684704d311b08331811cba8c081cda3d